### PR TITLE
Check implementation and interface function signatures match

### DIFF
--- a/python/sesame_rpc/lib/service.py
+++ b/python/sesame_rpc/lib/service.py
@@ -1,7 +1,6 @@
 import abc
 import inspect
 from functools import wraps
-from itertools import chain
 
 from google.protobuf.reflection import GeneratedProtocolMessageType
 
@@ -31,23 +30,35 @@ def rewrite_funcs(cls, iface):
         setattr(cls, func_name, new_func)
 
 
-def check_pb(func, arg_name, arg, annotation: GeneratedProtocolMessageType):
+def check_pb(func_name, arg_name, arg, annotation: GeneratedProtocolMessageType):
     if annotation is None:
         return
 
     if not isinstance(arg, annotation):
-        msg = ("%s() %s has expected type %s but received type %s" %
-               (func.__name__, arg_name, annotation.__name__, type(arg).__name__))
+        msg = ('%s() %s has expected type %s but received type %s' %
+               (func_name, arg_name, annotation.__name__, type(arg).__name__))
         raise TypeError(msg)
+
 
 def checked_func(iface_func, func):
     spec = inspect.getfullargspec(iface_func)
     annotations = spec.annotations
 
+    func_name = func.__name__
+    func_spec = inspect.getfullargspec(func)
+    if len(spec.args) != len(func_spec.args):
+        raise TypeError('%s() and the interface have different args signatures')
+    if len(spec.kwonlyargs) != len(func_spec.kwonlyargs):
+        raise TypeError('%s() and the interface have different kwonlyargs signatures')
+    if (spec.varargs is not None) != (func_spec.varargs is not None):
+        raise TypeError('%s() and the interface have different *args signatures')
+    if (spec.varkw is not None) != (func_spec.varkw is not None):
+        raise TypeError('%s() and the interface have different **kwargs signatures')
+
     @wraps(func)
     def _checked_func(*args, **kwargs):
-        for name, arg in chain(zip(spec.args, args), kwargs.items()):
-            check_pb(func, name, arg, annotations.get(name))
+        for name, arg in [*zip(spec.args, args), *kwargs.items()]:
+            check_pb(func_name, name, arg, annotations.get(name))
 
         result = func(*args, **kwargs)
         check_pb(func, 'return', result, annotations['return'])


### PR DESCRIPTION
`abc.ABCMeta` doesn't actually check if the concrete method has the same function spec as the abstract method so we'll need to do that manually :|
