### PR TITLE
Use protobuf-py3 protobuf_to_dict module.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 ## Dependencies
 
-sesame-rpc depends on a Python 3 port of protobuf-2.6.1. Such a port
-can be installed from the link:
+sesame-rpc depends on a Python 3 port of protobuf-2.6.1 which includes support for
+converting protobuf messages to and from JSON, which can be installed from the link:
 
 https://github.com/opendoor-labs/protobuf-py3.git@2.6.1#egg=protobuf-py3-2.6.1
 

--- a/python/sesame_rpc/flask/server.py
+++ b/python/sesame_rpc/flask/server.py
@@ -3,7 +3,7 @@ import json
 from functools import wraps
 
 from flask import Request, request, make_response
-from protobuf_to_dict import dict_to_protobuf, protobuf_to_dict
+from google.protobuf.protobuf_to_dict import dict_to_protobuf, protobuf_to_dict
 
 
 def sesame_api(iface_func):

--- a/python/sesame_rpc/flask/server.py
+++ b/python/sesame_rpc/flask/server.py
@@ -3,6 +3,11 @@ import json
 from functools import wraps
 
 from flask import Request, request, make_response
+
+# The protobuf_to_dict module here was copied from the protobuf3_to_dict PyPi
+# package into the Opendoor fork of protobuf-2.6.1.
+# Compare https://github.com/kaporzhu/protobuf-to-dict/blob/master/src/protobuf_to_dict.py
+# and https://github.com/opendoor-labs/protobuf-py3/blob/master/google/protobuf/protobuf_to_dict.py
 from google.protobuf.protobuf_to_dict import dict_to_protobuf, protobuf_to_dict
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,6 @@ setup(
         'itsdangerous==0.24',
         'Jinja2==2.8',
         'MarkupSafe==0.23',
-        'protobuf3-to-dict==0.1.2',
         'six==1.10.0',
         'Werkzeug==0.11.9',
     ],


### PR DESCRIPTION
I moved the protobuf_to_dict module into the Opendoor protobuf-py3 repo. This PR removes the dependency on the protobuf-to-dict PYPI package and uses the protobuf_to_dict module in the protobuf-py3 package. The reason is that the protobuf_to_dict PYPI package installs the non-Python 3 compatible protobuf library as a dependency, which we don't want.