### PR TITLE
Use https url for protobuf submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "protobuf"]
 	path = protobuf
-	url = git@github.com:google/protobuf.git
+	url = https://github.com/google/protobuf.git


### PR DESCRIPTION
Using the https url allows sesame-rpc to be pip installed in Travis CI. Without specifying https, pip defaults to ssh which fails.
